### PR TITLE
[FRONT-7] UX improvements

### DIFF
--- a/packages/graphql-server/src/api/githubApi.ts
+++ b/packages/graphql-server/src/api/githubApi.ts
@@ -1,12 +1,12 @@
 import axios, { AxiosResponse } from 'axios'
 import {
+  ContributorData,
+  GitHubCommitHistory,
+  GitHubInfo,
   GitHubOrganization,
   GitHubUser,
-  GitHubInfo,
-  GitHubCommitHistory,
   ProjectFounder,
-  RepositoryTopicsResponse,
-  ContributorData
+  RepositoryTopicsResponse
 } from '../../types/githubApi'
 
 const githubApiUrl = process.env.GITHUB_API_URL || ''
@@ -47,7 +47,7 @@ export async function getOrganizationInfo(
   const response: AxiosResponse<{ data: { organization: GitHubOrganization } }> = await axios.post(
     githubApiUrl,
     {
-      query: query
+      query
     },
     {
       headers: {
@@ -223,9 +223,9 @@ export async function getRepositoryTopics(
         }
       }
     )
-    // console.log(response.headers)
-    const linkHeader: string = response?.headers['link'] as string
-    const lastPageMatch: RegExpMatchArray | null = linkHeader.match(/page=(\d+)>; rel="last"/)
+
+    const linkHeader = response?.headers['link'] as string | undefined
+    const lastPageMatch = linkHeader?.match(/page=(\d+)>; rel="last"/)
     const lastPage: number = lastPageMatch ? parseInt(lastPageMatch[1]) : 1
     return lastPage
   } catch (error) {

--- a/packages/graphql-server/src/dbUpdater.ts
+++ b/packages/graphql-server/src/dbUpdater.ts
@@ -1,25 +1,24 @@
+import { ProjectInfo } from '../types/supabaseUtils'
+import { TrendingState } from '../types/updateProject'
+import { fetchTrendingRepos } from './scraping/githubScraping'
 import supabaseClient from './supabaseClient'
+import {
+  deleteNotTrendingAndNotBookmarkedProjects,
+  deleteStaleAssociatedPersons,
+  deleteStaleOrganizations,
+  getOrganizationID,
+  getPersonID,
+  getTrendingAndBookmarkedProjects,
+  purgeTrendingState,
+  repoIsAlreadyInDB
+} from './supabaseUtils'
 import {
   updateAllProjectInfo,
   updateProjectForkHistory,
   updateProjectGithubStats,
   updateProjectStarHistory,
-  updateProjectTrendingStatesForListOfRepos,
-  updateProjectTweets
+  updateProjectTrendingStatesForListOfRepos
 } from './updateProject'
-import {
-  getOrganizationID,
-  getPersonID,
-  purgeTrendingState,
-  repoIsAlreadyInDB,
-  deleteNotTrendingAndNotBookmarkedProjects,
-  getTrendingAndBookmarkedProjects,
-  deleteStaleOrganizations,
-  deleteStaleAssociatedPersons
-} from './supabaseUtils'
-import { fetchTrendingRepos } from './scraping/githubScraping'
-import { TrendingState } from '../types/updateProject'
-import { ProjectInfo } from '../types/supabaseUtils'
 
 export const automaticDbUpdater = async () => {
   console.log('Auto-DB-updater run at', new Date().toLocaleString())
@@ -136,7 +135,7 @@ const processTrendingRepos = async (repos: string[], trendingState: TrendingStat
 export const updateProjectDaily = async (project: ProjectInfo) => {
   await updateProjectGithubStats(project.name, project.owner)
   await updateProjectStarHistory(project.name, project.owner)
-  await updateProjectTweets(project.name, project.owner)
+  // await updateProjectTweets(project.name, project.owner)
 }
 
 /**

--- a/packages/graphql-server/src/scraping/githubScraping.ts
+++ b/packages/graphql-server/src/scraping/githubScraping.ts
@@ -27,6 +27,7 @@ export async function fetchTrendingRepos(timeMode2: timeMode) {
     trendingSplit.push(stringSplit[0])
     trendingSplit.push(stringSplit[1])
   })
+
   return trendingSplit
 }
 
@@ -61,7 +62,7 @@ export async function fetchRepositoryReadme(owner: string, name: string) {
       continue
     }
   }
-  console.log("ReadMe couldn't be found")
+  console.log("Readme couldn't be found")
   return ' '
 }
 

--- a/packages/graphql-server/src/updateProject.ts
+++ b/packages/graphql-server/src/updateProject.ts
@@ -1,23 +1,23 @@
-import supabaseClient from './supabaseClient'
-import {
-  getPersonID,
-  getProjectID,
-  updateSupabaseProject,
-  repoIsAlreadyInDB,
-  formatGithubStats,
-  getProjectAbout
-} from './supabaseUtils'
+import { GitHubInfo, ProjectFounder } from '../types/githubApi'
+import { ProjectUpdate } from '../types/supabaseUtils'
+import { TrendingState } from '../types/updateProject'
 import { getContributorCount, getRepoFounders, getRepositoryTopics } from './api/githubApi'
 import { getCategoriesFromGPT, getELI5FromReadMe, getHackernewsSentiment } from './api/openAIApi'
+import { getRepoForkRecords } from './githubHistory/forkHistory'
+import { getRepoStarRecords } from './githubHistory/starHistory'
 import { fetchRepositoryReadme } from './scraping/githubScraping'
 import { searchHackerNewsStories } from './scraping/hackerNewsScraping'
-import { getRepoStarRecords } from './githubHistory/starHistory'
-import { getGithubData } from './utils'
-import { GitHubInfo, ProjectFounder } from '../types/githubApi'
-import { TrendingState } from '../types/updateProject'
-import { ProjectUpdate } from '../types/supabaseUtils'
 import { getPostsForHashtag } from './scraping/twitterScraping'
-import { getRepoForkRecords } from './githubHistory/forkHistory'
+import supabaseClient from './supabaseClient'
+import {
+  formatGithubStats,
+  getPersonID,
+  getProjectAbout,
+  getProjectID,
+  repoIsAlreadyInDB,
+  updateSupabaseProject
+} from './supabaseUtils'
+import { getGithubData } from './utils'
 
 export {
   updateAllProjectInfo,
@@ -53,7 +53,7 @@ const updateAllProjectInfo = async (
   await updateProjectSentiment(repoName, owner)
   await updateProjectStarHistory(repoName, owner)
   await updateProjectForkHistory(repoName, owner)
-  await updateProjectTweets(repoName, owner)
+  // await updateProjectTweets(repoName, owner)
   await updateProjectCategories(repoName, owner)
   if (trendingState) {
     await updateProjectTrendingState(repoName, owner, trendingState)

--- a/packages/ui/src/components/domain/compare/CategoryModal.tsx
+++ b/packages/ui/src/components/domain/compare/CategoryModal.tsx
@@ -28,6 +28,7 @@ const CategoryModal: FC<CategoryModalProps> = ({ open, close, category, redirect
       // If the mutation was successful, show success message
       if (responseCode >= 200 && responseCode < 300) {
         redirect(newCategory)
+        close()
       } else {
         // Otherwise, show error message
         setError(res?.data?.renameBookmarkCategory?.message || defaultErrorMessage)
@@ -48,8 +49,14 @@ const CategoryModal: FC<CategoryModalProps> = ({ open, close, category, redirect
     // Reset success and error states
     setError(null)
 
-    // Don't do anything if the category is the same or empty
-    if (newCategory === category || newCategory.length === 0) return
+    // Don't do anything if the category is the same
+    if (newCategory === category) close()
+
+    // Show error message if the category is empty
+    if (newCategory.length === 0) {
+      setError('Category cannot be empty.')
+      return
+    }
 
     // Add or save bookmark
     void renameBookmarkCategory()
@@ -63,7 +70,7 @@ const CategoryModal: FC<CategoryModalProps> = ({ open, close, category, redirect
         <Input placeholder='Category' value={newCategory} onChange={handleChange} />
 
         {/* Error message */}
-        {error && <p className='text-sm text-red-400'>{defaultErrorMessage}</p>}
+        {error && <p className='text-sm text-red-400'>{error ?? defaultErrorMessage}</p>}
 
         <div className='flex w-full items-center justify-end'>
           {/* Submit button */}

--- a/packages/ui/src/components/domain/compare/index.tsx
+++ b/packages/ui/src/components/domain/compare/index.tsx
@@ -82,7 +82,7 @@ const CompareContent = ({ data, category, loading }: CompareContentProps) => {
             id: project.id as string,
             name: project.name as string,
             data:
-              selectedMetric === 'Stars'
+              selectedMetric === 'stars'
                 ? (project.starHistory as DataPoint[])
                 : (project.forkHistory as DataPoint[])
           })) ?? []

--- a/packages/ui/src/components/domain/details/BookmarkModal.tsx
+++ b/packages/ui/src/components/domain/details/BookmarkModal.tsx
@@ -10,6 +10,7 @@ import {
   useEditBookmarkCategoryMutation,
   useFilteredBookmarksQuery
 } from '@/graphql/generated/gql'
+import useSidebarSync from '../sidebar/useSidebarSync'
 
 const defaultErrorMessage = 'Something went wrong. Please try again later.'
 
@@ -33,6 +34,7 @@ const BookmarkModal: FC<BookmarkModalProps> = ({
   const [errors, setErrors] = useState<{ [key: string]: string | undefined }>({})
 
   const user = useUser()
+  const { sync } = useSidebarSync()
 
   const [{ data: bookmarks }] = useFilteredBookmarksQuery({
     variables: { userId: user?.id as string }
@@ -62,6 +64,7 @@ const BookmarkModal: FC<BookmarkModalProps> = ({
 
         // If the mutation was successful, show success message
         if (responseCode >= 200 && responseCode < 300) {
+          sync()
           close()
         } else {
           // Otherwise, show error message
@@ -78,6 +81,7 @@ const BookmarkModal: FC<BookmarkModalProps> = ({
 
         // If the mutation was successful, show success message
         if (responseCode >= 200 && responseCode < 300) {
+          sync()
           close()
         } else {
           // Otherwise, show error message
@@ -102,6 +106,7 @@ const BookmarkModal: FC<BookmarkModalProps> = ({
 
       // If the mutation was successful, show success message
       if (responseCode >= 200 && responseCode < 300) {
+        sync()
         close()
       } else {
         // Otherwise, show error message

--- a/packages/ui/src/components/domain/details/Notes.tsx
+++ b/packages/ui/src/components/domain/details/Notes.tsx
@@ -11,6 +11,7 @@ const Notes = ({ projectId }: NotesProps) => {
 
   const [notes, setNotes] = useState<string>(persistedNotes || '')
   const [isEditing, setIsEditing] = useState(false)
+  const [textAreaScrollHeight, setTextAreaScrollHeight] = useState(0)
 
   useEffect(() => {
     setNotes(persistedNotes || '')
@@ -37,20 +38,26 @@ const Notes = ({ projectId }: NotesProps) => {
           <Textarea
             value={notes}
             onChange={e => setNotes(e.target.value)}
+            onFocus={e => setTextAreaScrollHeight(e.currentTarget.scrollHeight)}
+            onInput={e => setTextAreaScrollHeight(e.currentTarget.scrollHeight)}
             onBlur={() => {
               localStorage.setItem(`notes-${projectId}`, notes)
               setIsEditing(false)
             }}
-            className='h-auto min-w-0 p-2'
-            rows={notes.split('\n').length}
+            className='no-scrollbar h-auto min-w-0 resize-none p-2'
+            style={{
+              height: `${textAreaScrollHeight + 2}px`,
+              transition: 'border-color 0.2s ease-in-out'
+            }}
             autoFocus
           />
         ) : (
           <div className='flex flex-col gap-2'>
             {notes ? (
               <p className='text-sm text-white'>
-                {notes.split('\n').map(line => (
-                  <span key={line}>
+                {notes.split('\n').map((line, index) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <span key={index}>
                     {line}
                     <br />
                   </span>

--- a/packages/ui/src/components/domain/details/Notes.tsx
+++ b/packages/ui/src/components/domain/details/Notes.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+import { FiEdit } from 'react-icons/fi'
+import Textarea from '@/components/shared/Textarea'
+
+type NotesProps = {
+  projectId: string
+}
+
+const Notes = ({ projectId }: NotesProps) => {
+  const persistedNotes = localStorage.getItem(`notes-${projectId}`)
+
+  const [notes, setNotes] = useState<string>(persistedNotes || '')
+  const [isEditing, setIsEditing] = useState(false)
+
+  useEffect(() => {
+    setNotes(persistedNotes || '')
+  }, [projectId])
+
+  return (
+    <div className='border-b border-solid border-white/5 px-4 py-3 text-sm font-normal leading-4 lg:px-7'>
+      <div className='flex items-center justify-between'>
+        <h3 className='py-2 text-xs font-medium uppercase text-white/50'>Notes</h3>
+        {!isEditing && (
+          <button
+            type='button'
+            className='text-sm text-white/50 hover:text-white'
+            onClick={() => setIsEditing(true)}>
+            <FiEdit />
+          </button>
+        )}
+
+        {isEditing && <p className='text-white/50'>Saving...</p>}
+      </div>
+
+      <div className='py-2.5'>
+        {isEditing ? (
+          <Textarea
+            value={notes}
+            onChange={e => setNotes(e.target.value)}
+            onBlur={() => {
+              localStorage.setItem(`notes-${projectId}`, notes)
+              setIsEditing(false)
+            }}
+            className='h-auto min-w-0 p-2'
+            rows={notes.split('\n').length}
+            autoFocus
+          />
+        ) : (
+          <div className='flex flex-col gap-2'>
+            {notes ? (
+              <p className='text-sm text-white'>
+                {notes.split('\n').map(line => (
+                  <span key={line}>
+                    {line}
+                    <br />
+                  </span>
+                ))}
+              </p>
+            ) : (
+              <p className='text-sm text-white/60'>No notes yet</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default Notes

--- a/packages/ui/src/components/domain/details/ProjectInformation.tsx
+++ b/packages/ui/src/components/domain/details/ProjectInformation.tsx
@@ -16,7 +16,7 @@ type ProjectInformationProps = {
   url: string
   explanation: string
   about: string
-  categories: string[]
+  // categories: string[]
   isBookmarked: boolean
   category?: string
   loading?: boolean
@@ -33,7 +33,6 @@ const ProjectInformation = ({
   name,
   explanation,
   about,
-  categories,
   isBookmarked,
   category,
   loading
@@ -85,17 +84,11 @@ const ProjectInformation = ({
             </a>
           )}
 
-          {categories?.length > 0 &&
-            categories[0] !== 'CategorizationError' &&
-            categories
-              .filter((value, index, array) => array.indexOf(value) === index)
-              .map(cat => (
-                <p
-                  key={cat}
-                  className='mx-1 rounded-md bg-white/5 px-2 py-0.5 text-xs font-normal text-white/75'>
-                  {cat}
-                </p>
-              ))}
+          {category && (
+            <span className='rounded-full border border-indigo-500/60 bg-indigo-500/60 px-3 py-1 text-xs text-white'>
+              {category}
+            </span>
+          )}
         </div>
 
         <div className='flex flex-row items-center justify-end gap-2'>

--- a/packages/ui/src/components/domain/details/RightSidebar.tsx
+++ b/packages/ui/src/components/domain/details/RightSidebar.tsx
@@ -8,6 +8,7 @@ import { Project } from '@/graphql/generated/gql'
 import { AffinityData } from '@/util/sendToAffinity'
 import SendToAffinity from '../settings/SendToAffinity'
 import GithubStats from './GithubStats'
+import Notes from './Notes'
 
 type RightSidebarProps = {
   project?: Project
@@ -89,6 +90,8 @@ const RightSidebar = ({ project, loading }: RightSidebarProps) => {
               <SendToAffinity {...sendToAffinityProps} />
             </div>
           </Box>
+
+          <Notes projectId={project.id as string} />
         </>
       ) : null}
     </SmallSidebar>

--- a/packages/ui/src/components/domain/details/index.tsx
+++ b/packages/ui/src/components/domain/details/index.tsx
@@ -139,7 +139,7 @@ const Details = ({ id }: DetailsProps) => {
             url={project?.githubUrl as string}
             explanation={project?.eli5 || 'No explanation'}
             about={project?.about || 'No description'}
-            categories={project?.categories as string[]}
+            // categories={project?.categories as string[]}
             isBookmarked={isBookmarked}
             category={category}
             loading={loading}

--- a/packages/ui/src/components/domain/sidebar/Group.tsx
+++ b/packages/ui/src/components/domain/sidebar/Group.tsx
@@ -1,0 +1,68 @@
+import { ReactNode, useEffect, useState } from 'react'
+import { HiOutlineFolder, HiOutlineFolderOpen } from 'react-icons/hi2'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { ArrowRightIcon } from '@primer/octicons-react'
+import clsx from 'clsx'
+
+type GroupProps = {
+  text: string
+  path: string
+  items: ReactNode[]
+}
+
+const Group = ({ text, path, items }: GroupProps) => {
+  const {
+    query: { category: categoryFromUrl }
+  } = useRouter()
+
+  const category =
+    (typeof categoryFromUrl === 'string' ? categoryFromUrl : categoryFromUrl?.join('')) || ''
+
+  const [isExpanded, setIsExpanded] = useState(category === text)
+
+  useEffect(() => {
+    setIsExpanded(category === text)
+  }, [category])
+
+  const Icon = isExpanded ? HiOutlineFolderOpen : HiOutlineFolder
+
+  return (
+    <div className='flex flex-col'>
+      <button
+        type='button'
+        onClick={() => setIsExpanded(!isExpanded)}
+        className='group relative flex w-full items-center justify-start gap-[5px] rounded-md px-5 py-2.5 transition-colors duration-75 hover:bg-white/5'>
+        <Icon className='h-4 w-4 text-white/50' />
+
+        <span
+          className='mt-[1px] h-[13px] w-[130px] overflow-hidden text-left text-xs leading-3 text-white/90'
+          style={{ textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {text}
+        </span>
+
+        <Link
+          href={path}
+          className='group/link invisible absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-1 overflow-hidden rounded-md px-2 py-1.5 text-white/50 opacity-0 transition-all duration-100 hover:bg-[#343435] group-hover:visible group-hover:opacity-100'>
+          <span className='invisible max-w-0 text-xs opacity-0 transition-all delay-100 duration-200 group-hover/link:visible group-hover/link:max-w-[55px] group-hover/link:opacity-100'>
+            Compare
+          </span>
+          <ArrowRightIcon className='h-4 w-4' />
+        </Link>
+      </button>
+
+      <div
+        className={clsx(
+          'flex flex-col gap-1 transition-all duration-200',
+          isExpanded ? 'visible opacity-100' : 'invisible opacity-0'
+        )}
+        style={{
+          maxHeight: isExpanded ? `${items.length * 36 + (items.length - 1) * 4}px` : '0px'
+        }}>
+        {items}
+      </div>
+    </div>
+  )
+}
+
+export default Group

--- a/packages/ui/src/components/domain/sidebar/Item.tsx
+++ b/packages/ui/src/components/domain/sidebar/Item.tsx
@@ -11,16 +11,11 @@ type ItemProps = {
   highlighted?: boolean
 }
 
-/**
- * Item for main sidebar (3 types: overview, category/ folder, project)
- */
 const Item = ({ Icon, imageSrc, text, path, secondaryItem, highlighted }: ItemProps) => (
   <div
     className={clsx(
       'relative flex flex-col justify-between rounded-md transition-colors duration-75 hover:bg-white/5',
-      {
-        'bg-white/10': highlighted
-      }
+      highlighted && 'bg-white/10'
     )}>
     <Link href={path}>
       <div className='inline-flex w-full items-center justify-between py-2.5 pl-5'>

--- a/packages/ui/src/components/domain/sidebar/NavSidebar.tsx
+++ b/packages/ui/src/components/domain/sidebar/NavSidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { FiCompass, FiBookmark, FiSettings, FiFolder } from 'react-icons/fi'
+import { FiCompass, FiBookmark, FiSettings } from 'react-icons/fi'
 import { LuLogOut } from 'react-icons/lu'
 import { withRouter } from 'next/router'
 import { useUser } from '@supabase/auth-helpers-react'
@@ -7,6 +7,7 @@ import Sidebar from '@/components/domain/sidebar'
 import Skeleton from '@/components/shared/Skeleton'
 import { Bookmark, useFilteredBookmarksQuery } from '@/graphql/generated/gql'
 import useSidebarCategories from '@/stores/useSidebarCategories'
+import Group from './Group'
 import Item from './Item'
 import MobileMenu from './MobileMenu'
 import Section from './Section'
@@ -36,12 +37,10 @@ const NavSidebar = () => {
 
       setBookmarks(edges?.map(edge => edge.node) as Bookmark[])
 
-      const bookmarksLength = edges?.length as number
       const newCategoriesLength = Array.from(new Set(edges?.map(edge => edge.node.category))).length
 
       // Only update categoriesLength if it has changed
-      if (newCategoriesLength !== categoriesLength)
-        setCategoriesLength(newCategoriesLength + bookmarksLength)
+      if (newCategoriesLength !== categoriesLength) setCategoriesLength(newCategoriesLength)
     }
   }, [urqlData])
 
@@ -67,31 +66,29 @@ const NavSidebar = () => {
           uniqueCategories.length > 0 ? (
             uniqueCategories.map(category => (
               <div key={category}>
-                <Item
+                <Group
                   key={category}
-                  Icon={FiFolder}
                   text={category as string}
                   path={`/compare/${encodeURIComponent(category as string)}`}
-                />
-                {/* Display all projects in a category under their corresponding folder */}
-                {bookmarks
-                  .filter(bookmark => bookmark.category === category)
-                  .map(({ project }) => {
-                    if (!project) return null
-                    const { name, organization, associatedPerson } = project
+                  items={bookmarks
+                    .filter(bookmark => bookmark.category === category)
+                    .map(({ project }) => {
+                      if (!project) return null
+                      const { name, organization, associatedPerson } = project
 
-                    return (
-                      <Item
-                        key={project.id as string}
-                        imageSrc={
-                          (organization?.avatarUrl || associatedPerson?.avatarUrl) as string
-                        }
-                        text={name as string}
-                        path={`/details/${project.id as string}`}
-                        secondaryItem
-                      />
-                    )
-                  })}
+                      return (
+                        <Item
+                          key={project.id as string}
+                          imageSrc={
+                            (organization?.avatarUrl || associatedPerson?.avatarUrl) as string
+                          }
+                          text={name as string}
+                          path={`/details/${project.id as string}`}
+                          secondaryItem
+                        />
+                      )
+                    })}
+                />
               </div>
             ))
           ) : (

--- a/packages/ui/src/components/domain/sidebar/NavSidebar.tsx
+++ b/packages/ui/src/components/domain/sidebar/NavSidebar.tsx
@@ -64,33 +64,36 @@ const NavSidebar = () => {
             </div>
           ) : // Display categories as folders
           uniqueCategories.length > 0 ? (
-            uniqueCategories.map(category => (
-              <div key={category}>
-                <Group
-                  key={category}
-                  text={category as string}
-                  path={`/compare/${encodeURIComponent(category as string)}`}
-                  items={bookmarks
-                    .filter(bookmark => bookmark.category === category)
-                    .map(({ project }) => {
-                      if (!project) return null
-                      const { name, organization, associatedPerson } = project
+            uniqueCategories
+              .sort((a, b) => (a ?? '').localeCompare(b ?? ''))
+              .map(category => (
+                <div key={category}>
+                  <Group
+                    key={category}
+                    text={category as string}
+                    path={`/compare/${encodeURIComponent(category as string)}`}
+                    items={bookmarks
+                      .filter(bookmark => bookmark.category === category)
+                      .sort((a, b) => (a.project.name ?? '').localeCompare(b.project.name ?? ''))
+                      .map(({ project }) => {
+                        if (!project) return null
+                        const { name, organization, associatedPerson } = project
 
-                      return (
-                        <Item
-                          key={project.id as string}
-                          imageSrc={
-                            (organization?.avatarUrl || associatedPerson?.avatarUrl) as string
-                          }
-                          text={name as string}
-                          path={`/details/${project.id as string}`}
-                          secondaryItem
-                        />
-                      )
-                    })}
-                />
-              </div>
-            ))
+                        return (
+                          <Item
+                            key={project.id as string}
+                            imageSrc={
+                              (organization?.avatarUrl || associatedPerson?.avatarUrl) as string
+                            }
+                            text={name as string}
+                            path={`/details/${project.id as string}`}
+                            secondaryItem
+                          />
+                        )
+                      })}
+                  />
+                </div>
+              ))
           ) : (
             <p className='py-2.5 pl-5 text-xs text-white/90'>No bookmarks yet</p>
           )}

--- a/packages/ui/src/components/domain/sidebar/Section.tsx
+++ b/packages/ui/src/components/domain/sidebar/Section.tsx
@@ -10,9 +10,7 @@ const Section = ({ children, title }: SectionProps) => (
   <div
     className={clsx(
       'border-t border-solid border-white/5 py-2.5 text-sm font-normal leading-4 text-white/90',
-      {
-        'no-scrollbar max-h-[calc(100vh-270px)] overflow-y-scroll': title === 'Categories'
-      }
+      title === 'Categories' && 'no-scrollbar h-[calc(100vh_-_270px)] overflow-y-scroll'
     )}>
     <p className='px-7 py-2.5 text-xs font-medium uppercase text-white/50'>{title}</p>
     <div className='px-2'>{children}</div>

--- a/packages/ui/src/components/domain/sidebar/useSidebarSync.ts
+++ b/packages/ui/src/components/domain/sidebar/useSidebarSync.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+interface SidebarSync {
+  counter: number
+  sync: () => void
+}
+
+const useSidebarSync = create<SidebarSync>(set => ({
+  counter: 0,
+  sync: () => set(state => ({ counter: state.counter + 1 }))
+}))
+
+export default useSidebarSync

--- a/packages/ui/src/components/shared/Textarea.tsx
+++ b/packages/ui/src/components/shared/Textarea.tsx
@@ -1,12 +1,17 @@
 import { DetailedHTMLProps, TextareaHTMLAttributes } from 'react'
+import { twMerge } from 'tailwind-merge'
 
-const Textarea = (
-  props: DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement>
-) => (
+const Textarea = ({
+  className,
+  ...props
+}: DetailedHTMLProps<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement>) => (
   <textarea
     // eslint-disable-next-line react/jsx-props-no-spreading
     {...props}
-    className='h-96 w-full min-w-[250px] rounded-md border border-white/5 bg-white/5 px-3 py-2.5 text-sm text-white outline-none backdrop-blur-xl transition-all duration-75 placeholder:text-white/40 focus:ring-2 focus:ring-indigo-500'
+    className={twMerge(
+      'h-96 w-full min-w-[250px] rounded-md border border-white/5 bg-white/5 px-3 py-2.5 text-sm text-white outline-none backdrop-blur-xl transition-all duration-75 placeholder:text-white/40 focus:ring-2 focus:ring-indigo-500',
+      className
+    )}
   />
 )
 

--- a/packages/ui/src/components/shared/chart/Chart.tsx
+++ b/packages/ui/src/components/shared/chart/Chart.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react'
 import { Chart } from 'react-chartjs-2'
-import type { ChartData } from 'chart.js'
+import type { ChartData, ChartEvent, LegendItem } from 'chart.js'
 import { Chart as ChartJS, registerables } from 'chart.js'
 import 'chartjs-adapter-moment'
 import resolveConfig from 'tailwindcss/resolveConfig'
@@ -27,6 +28,8 @@ const colors = colorValues
   .flatMap(value => [indigoColors?.[value]].filter(Boolean))
   .concat(singleColorValues)
 
+const gray = (fullConfig.theme?.colors?.gray as ColorObject)[800]
+
 export type DataPoint = {
   date: string
   count: number
@@ -44,18 +47,50 @@ export type ChartProps = {
  * Linechart with one or more datasets
  */
 const ChartComponent = ({ datasets }: ChartProps) => {
+  const [activeDatasetIndex, setActiveDatasetIndex] = useState<number>()
+
   const chartData: ChartData<'line'> = {
-    datasets: datasets.map(({ name, data }, index) => ({
-      data: data?.map(({ date, count }) => ({ x: new Date(date).getTime(), y: count })),
-      backgroundColor: `${colors[index % colors.length]}30`,
-      borderColor: colors[index % colors.length],
-      label: name
-    }))
+    datasets: datasets.map(({ name, data }, index) => {
+      const isActive = index === activeDatasetIndex || activeDatasetIndex === undefined
+      const baseColor = colors[index % colors.length]
+      const backgroundColor = `${isActive ? baseColor : gray}30`
+      const borderColor = isActive ? baseColor : gray
+
+      return {
+        data: data?.map(({ date, count }) => ({ x: new Date(date).getTime(), y: count })),
+        backgroundColor,
+        borderColor,
+        label: name
+      }
+    })
+  }
+
+  const handleLegendItemHover = (_e: ChartEvent, legendItem: LegendItem) => {
+    setActiveDatasetIndex(legendItem.datasetIndex)
+  }
+
+  const handleLegendItemLeave = () => {
+    setActiveDatasetIndex(undefined)
   }
 
   return (
     <div className='mt-6 h-96 w-full'>
-      <Chart type='line' data={chartData} options={chartOptions} className='!w-full' />
+      <Chart
+        type='line'
+        data={chartData}
+        options={{
+          ...chartOptions,
+          plugins: {
+            ...chartOptions.plugins,
+            legend: {
+              ...chartOptions.plugins?.legend,
+              onHover: handleLegendItemHover,
+              onLeave: handleLegendItemLeave
+            }
+          }
+        }}
+        className='!w-full'
+      />
     </div>
   )
 }

--- a/packages/ui/src/components/shared/chart/Chart.tsx
+++ b/packages/ui/src/components/shared/chart/Chart.tsx
@@ -83,6 +83,7 @@ const ChartComponent = ({ datasets }: ChartProps) => {
           plugins: {
             ...chartOptions.plugins,
             legend: {
+              display: chartData.datasets.length > 1,
               ...chartOptions.plugins?.legend,
               onHover: handleLegendItemHover,
               onLeave: handleLegendItemLeave

--- a/packages/ui/src/graphql/generated/gql.ts
+++ b/packages/ui/src/graphql/generated/gql.ts
@@ -1260,6 +1260,8 @@ export type FilteredBookmarksQueryVariables = Exact<{
   userId: Scalars['UUID']
   category?: InputMaybe<Scalars['String']>
   projectId?: InputMaybe<Scalars['UUID']>
+  first?: InputMaybe<Scalars['Int']>
+  after?: InputMaybe<Scalars['Cursor']>
 }>
 
 export type FilteredBookmarksQuery = {
@@ -1283,6 +1285,7 @@ export type FilteredBookmarksQuery = {
         }
       }
     }>
+    pageInfo: { __typename?: 'PageInfo'; hasNextPage: boolean; endCursor?: string | null }
   } | null
 }
 
@@ -1523,13 +1526,21 @@ export function useBookmarkIdsQuery(
   })
 }
 export const FilteredBookmarksDocument = gql`
-  query FilteredBookmarks($userId: UUID!, $category: String, $projectId: UUID) {
+  query FilteredBookmarks(
+    $userId: UUID!
+    $category: String
+    $projectId: UUID
+    $first: Int
+    $after: Cursor
+  ) {
     bookmarkCollection(
       filter: {
         userId: { eq: $userId }
         category: { eq: $category }
         projectId: { eq: $projectId }
       }
+      first: $first
+      after: $after
     ) {
       edges {
         node {
@@ -1548,6 +1559,10 @@ export const FilteredBookmarksDocument = gql`
             }
           }
         }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
       }
     }
   }

--- a/packages/ui/src/graphql/queries/filteredBookmarks.graphql
+++ b/packages/ui/src/graphql/queries/filteredBookmarks.graphql
@@ -1,6 +1,14 @@
-query FilteredBookmarks($userId: UUID!, $category: String, $projectId: UUID) {
+query FilteredBookmarks(
+  $userId: UUID!
+  $category: String
+  $projectId: UUID
+  $first: Int
+  $after: Cursor
+) {
   bookmarkCollection(
     filter: { userId: { eq: $userId }, category: { eq: $category }, projectId: { eq: $projectId } }
+    first: $first
+    after: $after
   ) {
     edges {
       node {
@@ -19,6 +27,10 @@ query FilteredBookmarks($userId: UUID!, $category: String, $projectId: UUID) {
           }
         }
       }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
     }
   }
 }


### PR DESCRIPTION
### Description of issue

- [x] Fix compare page chart metric selection bug
- [x] Make sidebar categories collapsible
- [x] Sort sidebar categories + bookmarks alphabetically
- [x] Fetch all bookmarks in sidebar query (add missing pagination)
- [x] Show project category tag on details page
- [x] Improve edit category modal UX
- [x] Refetch sidebar after updating bookmarks
- [x] Gray out chart datasets when hovering legend
- [x] Hide chart legend on detail page/ if there's only 1 dataset
- [x] Add notes field to project details page (persisted in localStorage)

### How I implemented

<img width="591" alt="Screenshot 2023-12-14 at 16 13 35" src="https://github.com/viets-software-club/truffle-ai/assets/37487191/39f558eb-5947-4b5c-bbb9-1c4e4ec7744b">
<img width="921" alt="Screenshot 2023-12-14 at 17 11 04" src="https://github.com/viets-software-club/truffle-ai/assets/37487191/56a62fd4-d674-40b1-99a6-09fce5b18dac">
<img width="253" alt="Screenshot 2023-12-14 at 17 27 54" src="https://github.com/viets-software-club/truffle-ai/assets/37487191/95e6023d-cb4c-45ae-9f4e-ab95f854608b">
